### PR TITLE
Windows Slaves plugin failed to install due to mismatching artifact and group id.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,8 +219,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hudsonci.plugins</groupId>
-            <artifactId>windows-slaves-plugin</artifactId>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>windows-slaves</artifactId>
             <version>1.0</version>
         </dependency>
 


### PR DESCRIPTION
When updating the list of available plugins in the update center, I receive:

```
Jul 20, 2014 10:46:54 PM hudson.model.UpdateSite$Plugin getNeededDependencies
WARNING: Could not find dependency windows-slaves-plugin of multi-slave-config-plugin
```

Installing the multi slave conrfig plugin, I then get: 

```
Jul 20, 2014 10:47:48 PM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin multi-slave-config-plugin
java.io.IOException: Dependency windows-slaves-plugin (1.0) doesn't exist
    at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:488)
    at hudson.PluginManager$2$1$1.run(PluginManager.java:356)
    at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
    at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
    at jenkins.model.Jenkins$7.runTask(Jenkins.java:899)
    at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
    at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:895)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:918)
    at java.lang.Thread.run(Thread.java:662)
```

These code changes successfully download the windows slaves plugin and remove the errors.
