### PR TITLE
adjust to work with updated stapler from 1.580-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.554</version>
+        <version>1.580.1</version>
     </parent>
 
     <groupId>com.sonyericsson.hudson.plugins.multi-slave-config-plugin</groupId>

--- a/src/main/java/com/sonyericsson/hudson/plugins/multislaveconfigplugin/NodeManageLink.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/multislaveconfigplugin/NodeManageLink.java
@@ -725,15 +725,13 @@ public class NodeManageLink extends ManagementLink implements Describable<NodeMa
 
     /**
      * Requests the selected slaves to go online.
-     * @param rsp StaplerResponse.
-     * @param req StaplerRequest.
      * @return false if no nodes were selected, otherwise true
      */
     @JavaScriptMethod
-    public boolean takeOnline(StaplerRequest req, StaplerResponse rsp) {
+    public boolean takeOnline() {
         // Throws exception on failure. This is handled at a higher level.
         Hudson.getInstance().checkPermission(getRequiredPermission());
-        String currentSessionId = req.getSession().getId();
+        String currentSessionId = Stapler.getCurrentRequest().getSession().getId();
         NodeList nodeList = getNodeList(currentSessionId);
 
         boolean result = false;
@@ -754,15 +752,13 @@ public class NodeManageLink extends ManagementLink implements Describable<NodeMa
     /**
      * Requests the selected slaves to go offline.
      * @param reason String.
-     * @param rsp StaplerResponse.
-     * @param req StaplerRequest.
      * @return false if no nodes were selected, otherwise true
      */
     @JavaScriptMethod
-    public boolean takeOffline(String reason, StaplerRequest req, StaplerResponse rsp) {
+    public boolean takeOffline(String reason) {
         // Throws exception on failure. This is handled at a higher level.
         Hudson.getInstance().checkPermission(getRequiredPermission());
-        String currentSessionId = req.getSession().getId();
+        String currentSessionId = Stapler.getCurrentRequest().getSession().getId();
         NodeList nodeList = getNodeList(currentSessionId);
 
         boolean result = false;
@@ -787,15 +783,13 @@ public class NodeManageLink extends ManagementLink implements Describable<NodeMa
 
     /**
      * Requests the selected slaves to go offline leniently. Only possible if Lenient Shutdown Plugin is installed.
-     * @param rsp StaplerResponse.
-     * @param req StaplerRequest.
      * @return false if no nodes were selected or something else goes wrong, otherwise true
      */
     @JavaScriptMethod
-    public boolean takeOfflineLeniently(StaplerRequest req, StaplerResponse rsp) {
+    public boolean takeOfflineLeniently() {
         // Throws exception on failure. This is handled at a higher level.
         Hudson.getInstance().checkPermission(getRequiredPermission());
-        String currentSessionId = req.getSession().getId();
+        String currentSessionId = Stapler.getCurrentRequest().getSession().getId();
         NodeList nodeList = getNodeList(currentSessionId);
 
         boolean takenOffline = false;
@@ -819,15 +813,13 @@ public class NodeManageLink extends ManagementLink implements Describable<NodeMa
 
     /**
      * Connects (not forced) to selected slaves.
-     * @param rsp StaplerResponse.
-     * @param req StaplerRequest.
      * @return false if no nodes were selected, otherwise true
      */
     @JavaScriptMethod
-    public boolean connectSlaves(StaplerRequest req, StaplerResponse rsp) {
+    public boolean connectSlaves() {
         // Throws exception on failure. This is handled at a higher level.
         Hudson.getInstance().checkPermission(getRequiredPermission());
-        String currentSessionId = req.getSession().getId();
+        String currentSessionId = Stapler.getCurrentRequest().getSession().getId();
         NodeList nodeList = getNodeList(currentSessionId);
 
         boolean result = false;
@@ -855,15 +847,13 @@ public class NodeManageLink extends ManagementLink implements Describable<NodeMa
     /**
      * Disconnects from selected slaves.
      * @param reason the reason for disconnecting
-     * @param rsp StaplerResponse.
-     * @param req StaplerRequest.
      * @return false if no nodes were selected, otherwise true
      */
     @JavaScriptMethod
-    public boolean disconnectSlaves(String reason, StaplerRequest req, StaplerResponse rsp) {
+    public boolean disconnectSlaves(String reason) {
         // Throws exception on failure. This is handled at a higher level.
         Hudson.getInstance().checkPermission(getRequiredPermission());
-        String currentSessionId = req.getSession().getId();
+        String currentSessionId = Stapler.getCurrentRequest().getSession().getId();
         NodeList nodeList = getNodeList(currentSessionId);
 
         boolean result = false;


### PR DESCRIPTION
updated stapler, bundled by jenkins-core1.580-1 or newer, verifies 1) the request parameter from browser and 2) pre-designed parameter defined in @JavaScriptMethod method strictly before binding it .
https://github.com/stapler/stapler/commit/70e23a3510091fedc45fc13489588b37c1199e04
possible similar issue: https://issues.jenkins-ci.org/browse/JENKINS-25875

Functions under "Manage slaves" cause unchecked exception as mismatch in these parameters are detected. This needs to be fixed to work with newer jenkins version.  
